### PR TITLE
[FIX] Return the result check in case of non multi task as well

### DIFF
--- a/tasks/deps-ok.js
+++ b/tasks/deps-ok.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
       // get arguments from command line manually
       var verbose = process.argv.some(isVerbose);
       var force = process.argv.some(isForce);
-      checkDeps({
+      return checkDeps({
         verbose: verbose,
         force: force
       });


### PR DESCRIPTION
Missing return that confuses grunt since return value is always null.

````sh
› grunt deps-ok
Running "deps-ok" task
ERROR: lodash ~3.6.0 needed, but found 2.4.1
>> problem with dependencies, probably run `npm install`

Done, without errors.
````